### PR TITLE
Update local_deploy.py

### DIFF
--- a/src/local_deploy.py
+++ b/src/local_deploy.py
@@ -20,6 +20,10 @@ import pyaudio
 import webrtcvad
 import logging
 
+#解决bug问题root - INFO - stop recording...
+import os
+os.environ["KMP_DUPLICATE_LIB_OK"]="TRUE"
+
 logging.basicConfig(
     level=logging.INFO,
     format='%(name)s - %(levelname)s - %(message)s')


### PR DESCRIPTION
运行该程序，出现下面问题：
```shell
User
root - INFO - start recording...
root - INFO - stop recording...
faster_whisper - INFO - Processing audio with duration 00:05.610
OMP: Error #15: Initializing libiomp5md.dll, but found libiomp5md.dll already initialized.
OMP: Hint This means that multiple copies of the OpenMP runtime have been linked into the program. That is dangerous, since it can degrade performance or cause incorrect results. The best thing to do is to ensure that only a sin
gle OpenMP runtime is linked into the process, e.g. by avoiding static linking of the OpenMP runtime in any library. As an unsafe, unsupported, undocumented workaround you can set the environment variable KMP_DUPLICATE_LIB_OK=TR
UE to allow the program to continue to execute, but that may cause crashes or silently produce incorrect results. For more information, please see http://www.intel.com/software/products/support/.
```

在本地环境变量中更改无效果（windows10），在源代码上添加os库进行环境变量更改，成功！特此申请合并